### PR TITLE
Fix: page does not load without refresh

### DIFF
--- a/pkg/app-launcher/routing/extension-routing.ts
+++ b/pkg/app-launcher/routing/extension-routing.ts
@@ -1,8 +1,9 @@
 import type { RouteConfig } from 'vue-router';
 import { PRODUCT_NAME } from '../config/app-launcher';
+import AppLauncher from "../pages/app-launcher.vue";
 
 const MAIN_APP_LAUNCHER_LOCATION: RouteConfig = {
-  component: () => import('../pages/app-launcher.vue'),
+  component: () => AppLauncher,
   name: PRODUCT_NAME,
   path: `/${PRODUCT_NAME}`,
 };


### PR DESCRIPTION
fixes [SUSE1-47](https://krumtest.atlassian.net/browse/SUSE1-47)

The page did not load until refresh, and seemingly was caused by the dynamic import of the AppLauncher component in the routing definition.

Adjusted this with a standard import.

[SUSE1-47]: https://krumtest.atlassian.net/browse/SUSE1-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ